### PR TITLE
Documentation: moved 'ESP32 Compatibility' to subsection

### DIFF
--- a/docs/bearssl-client-secure-class.rst
+++ b/docs/bearssl-client-secure-class.rst
@@ -120,7 +120,7 @@ Valid values for min and max are `BR_TLS10`, `BR_TLS11`, `BR_TLS12`.  Min and ma
 
 
 ESP32 Compatibility
-===================
+~~~~~~~~~~~~~~~~~~~
 Simple ESP32 ``WiFiClientSecure`` compatibility is built-in, allow for some sketches to run without any modification.
 The following methods are implemented:
 


### PR DESCRIPTION
Hi,

It seems as though the section 'ESP32 Compatibility' is one level too high in the documentation of 'WiFiClientSecure Class'. Lowered to be a subsection thereof and avoid appearing as separate in the contents.

Best regards,
djpearman